### PR TITLE
support push tokens and browser name

### DIFF
--- a/lib/mapper.js
+++ b/lib/mapper.js
@@ -8,6 +8,7 @@ var unixTime = require('unix-time');
 var foldl = require('@ndhoule/foldl');
 var trample = require('@segment/trample');
 var is = require('is');
+var parseUserAgent = require('ua-parser-js');
 
 /**
  * Map identify.
@@ -88,6 +89,7 @@ function addDeviceParams(facade, payload) {
   // device props
   payload.dev_id = getOrGenerateDevId(facade, payload);
   payload.dev_name = facade.proxy('context.device.model');
+  payload.push_token = facade.proxy('context.device.token');
 
   // app props
   payload.app_name = facade.proxy('context.app.name');
@@ -103,9 +105,13 @@ function addDeviceParams(facade, payload) {
     if (payload.os_name === 'iphone os') {
       payload.os_name = 'ios';
     } else {
-      // don't send anything if it's not `Android` or `iPhone OS`.
-      // Kahuna will record it as a `web` user on their end.
-      delete payload.os_name;
+      var browserName = parseUserAgent(facade.userAgent()).browser.name.toLowerCase();
+      var acceptedBrowsersList = ['chrome', 'safari', 'firefox'];
+      if (acceptedBrowsersList.indexOf(browserName) != -1) {
+        payload.os_name = browserName;
+      } else {
+        payload.os_name = 'web';
+      }
     }
   }
   payload.os_version = facade.proxy('context.os.version');

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "reject": "0.0.1",
     "segmentio-integration": "^3.0.5",
     "string-hash": "1.1.0",
+    "ua-parser-js": "^0.7.10",
     "unix-time": "^1.0.1"
   },
   "devDependencies": {

--- a/test/fixtures/identify-token.json
+++ b/test/fixtures/identify-token.json
@@ -1,27 +1,25 @@
 {
   "input": {
-    "type": "track",
-    "timestamp": "2016",
-    "event": "Damn Daniel",
-    "userId": "111",
-    "properties": {
-      "shoes": "White Vans",
-      "boolean": true,
-      "number": 3,
-      "shouldNotBeIncluded": null
+    "type": "identify",
+    "userId": "coconut1234",
+    "traits": {
+      "firstName": "Han",
+      "lastName": "Kim",
+      "email": "water@water.com",
+      "username": "food"
     },
     "context": {
-     "ip": "10.0.0.2",
+      "ip": "10.0.0.2",
       "app": {
         "name": "Test",
         "version": "1.0"
       },
       "device": {
         "name": "test-device",
-        "model": "1.2",
+        "model": "1.8",
         "manufacturer": "some-brand",
         "advertisingId": "id-for-attribution",
-        "id": "999999",
+        "id": "120398102397",
         "token": "ff15bc0c20c4aa6cd50854ff165fd265c838e5405bfeb9571066395b8c9da449"
       },
       "os": {
@@ -39,25 +37,19 @@
       "referrer": {
         "type": "other",
         "id": "some-id"
-      },
-      "traits": {
-        "firstName": "Han",
-        "lastName": "Kim",
-        "email": "bulgogi@bulgogi.com",
-        "username": "food"
       }
     }
   },
   "output": {
-    "dev_id": "999999",
-    "events": "[{\"event\":\"Damn Daniel\",\"time\":1451606400,\"properties\":{\"shoes\":[\"White Vans\"],\"boolean\":[\"true\"],\"number\":[\"3\"]}}]",
-    "credentials": "{\"user_id\":\"111\",\"email\":\"bulgogi@bulgogi.com\"}",
-    "user_info": "{\"firstName\":\"Han\",\"lastName\":\"Kim\",\"email\":\"bulgogi@bulgogi.com\",\"username\":\"food\",\"id\":\"111\"}",
+    "dev_id": "120398102397",
+    "credentials": "{\"user_id\":\"coconut1234\",\"email\":\"water@water.com\"}",
+    "user_info": "{\"firstName\":\"Han\",\"lastName\":\"Kim\",\"email\":\"water@water.com\",\"username\":\"food\",\"id\":\"coconut1234\"}",
+    "event": "user_created_or_updated_segment",
     "app_name": "Test",
     "app_ver": "1.0",
     "os_name": "android",
     "os_version": "7.0",
-    "dev_name": "1.2",
+    "dev_name": "1.8",
     "push_token": "ff15bc0c20c4aa6cd50854ff165fd265c838e5405bfeb9571066395b8c9da449"
   }
 }

--- a/test/fixtures/identify-useragent.json
+++ b/test/fixtures/identify-useragent.json
@@ -1,0 +1,36 @@
+{
+  "input": {
+    "type": "identify",
+    "timestamp": "2016",
+    "userId": "800001",
+    "traits": {
+      "email": "kanye3@west.com"
+    },
+    "context": {
+     "ip": "10.0.0.2",
+      "app": {
+        "name": "Test",
+        "version": "1.0"
+      },
+      "device": {
+        "name": "test-device",
+        "model": "1.4",
+        "manufacturer": "some-brand",
+        "advertisingId": "id-for-attribution",
+        "id": "141414",
+        "token": "ff15bc0c20c4aa6cd50854ff165fd265c838e5405bfeb9571066395b8c9da449"
+      },
+      "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_3) AppleWebKit/537.75.14 (KHTML, like Gecko) Version/7.0.3 Safari/7046A194A"
+    }
+  },
+  "output": {
+    "dev_id": "141414",
+    "event": "user_created_or_updated_segment",
+    "credentials": "{\"user_id\":\"800001\",\"email\":\"kanye3@west.com\"}",
+    "app_name": "Test",
+    "app_ver": "1.0",
+    "dev_name": "1.4",
+    "push_token": "ff15bc0c20c4aa6cd50854ff165fd265c838e5405bfeb9571066395b8c9da449",
+    "user_info": "{\"email\":\"kanye3@west.com\",\"id\":\"800001\"}"
+  }
+}

--- a/test/index.js
+++ b/test/index.js
@@ -86,6 +86,20 @@ describe('Kahuna', function(){
         .end(done);
     });
 
+    it('should send push token', function(done){
+      var json = test.fixture('identify-token');
+
+      json.output.key = settings.apiKey;
+      json.output.env = settings.env ? 'p' : 's';
+
+      var output = json.output;
+      test
+        .identify(json.input)
+        .sends(json.output)
+        .expects(200)
+        .end(done);
+    });
+
     it('identify should have dev_id', function(done){
       var json = test.fixture('identify-no-dev-id');
 
@@ -98,6 +112,62 @@ describe('Kahuna', function(){
         .sends(json.output)
         .expects(200)
         .end(done);
+    });
+
+    it('should map useragent for firefox', function(done){
+      var json = test.fixture('identify-useragent');
+      json.input.context.userAgent = 'Mozilla/5.0 (Windows NT 6.1; WOW64; rv:40.0) Gecko/20100101 Firefox/40.1';
+      json.output.os_name = 'firefox';
+      json.output.key = settings.apiKey;
+      json.output.env = settings.env ? 'p' : 's';
+
+      test
+        .identify(json.input)
+        .sends(json.output)
+        .expects(200)
+        .end(done)
+    });
+
+    it('should map useragent for chrome', function(done){
+      var json = test.fixture('identify-useragent');
+      json.input.context.userAgent = 'Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2228.0 Safari/537.36';
+      json.output.os_name = 'chrome';
+      json.output.key = settings.apiKey;
+      json.output.env = settings.env ? 'p' : 's';
+
+      test
+        .identify(json.input)
+        .sends(json.output)
+        .expects(200)
+        .end(done)
+    });
+
+    it('should map useragent for safari', function(done){
+      var json = test.fixture('identify-useragent');
+      json.input.context.userAgent = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_3) AppleWebKit/537.75.14 (KHTML, like Gecko) Version/7.0.3 Safari/7046A194A';
+      json.output.os_name = 'safari';
+      json.output.key = settings.apiKey;
+      json.output.env = settings.env ? 'p' : 's';
+
+      test
+        .identify(json.input)
+        .sends(json.output)
+        .expects(200)
+        .end(done)
+    });
+
+    it('should fallback to web for useragent', function(done){
+      var json = test.fixture('identify-useragent');
+      json.input.context.userAgent = 'Mozilla/5.0 (Windows NT 6.1; WOW64; Trident/7.0; AS; rv:11.0) like Gecko';
+      json.output.os_name = 'web';
+      json.output.key = settings.apiKey;
+      json.output.env = settings.env ? 'p' : 's';
+
+      test
+        .identify(json.input)
+        .sends(json.output)
+        .expects(200)
+        .end(done)
     });
   });
 


### PR DESCRIPTION
This adds ability to send `device.token` via `push_token`. Also updated logic handling for their `os_name` as per their updated docs.

https://app.usekahuna.com/tap/public_docs/Content/APIs/Server.htm#Device_Parameters

Did end to end testing and saw everything in the UI.

@segment-integrations/core 